### PR TITLE
Dev laser controls widget

### DIFF
--- a/assembly/assemblyCommon/LStepExpressMeasurement.cc
+++ b/assembly/assemblyCommon/LStepExpressMeasurement.cc
@@ -37,6 +37,9 @@ LStepExpressMeasurement::LStepExpressMeasurement(LStepExpressModel* model, LStep
     connect(this, SIGNAL(nextScanStep()),
 	this, SLOT(doNextScanStep()));
 
+    connect(laserModel_, SIGNAL(deviceStateChanged(State)),
+            this,SLOT(setLaserEnabled(State)));
+
     generateCirclePositions();
 
     //spyNextScanStep_ = new QSignalSpy(this, SIGNAL(nextScanStep()));
@@ -182,10 +185,14 @@ void LStepExpressMeasurement::stopMeasurement()
   currentIndex_ = tableSize_;
 }
 
-void LStepExpressMeasurement::setLaserEnabled(bool enabled)
+void LStepExpressMeasurement::setLaserEnabled(State newState)
 {
   //    NQLog("LStepExpressMeasurement ", NQLog::Debug) << "setLaserEnabled";
-    isLaserEnabled_ = enabled;
+    if(newState == READY){
+        isLaserEnabled_ = true;
+    }else{
+        isLaserEnabled_ = false;
+    }
 }
 
 void LStepExpressMeasurement::takeMeasurement()

--- a/assembly/assemblyCommon/LStepExpressMeasurement.h
+++ b/assembly/assemblyCommon/LStepExpressMeasurement.h
@@ -56,7 +56,7 @@ public slots:
     void setAverageMeasEnabled(bool);
     void setZigZag(bool);
     void takeMeasurement();
-    void setLaserEnabled(bool);
+    void setLaserEnabled(State newState);
 
 private:
     bool averageMeasEnabled_;

--- a/assembly/assemblyCommon/LStepExpressMeasurementWidget.cc
+++ b/assembly/assemblyCommon/LStepExpressMeasurementWidget.cc
@@ -18,7 +18,7 @@ LStepExpressMeasurementWidget::LStepExpressMeasurementWidget(LStepExpressModel* 
     zigzagCheckBox_ = new QCheckBox("Zigzag motion (default is meander)", this);
     buttonStartMeasurement_ = new QPushButton("Start Measurement", this);
     buttonStartMeasurement_->setEnabled(false);
-    checkBoxEnableLaser_ = new QCheckBox("Enable Laser", this);
+    //checkBoxEnableLaser_ = new QCheckBox("Enable Laser", this);
     buttonStopMeasurement_ = new QPushButton("Stop Measurement", this);
     buttonStopMeasurement_->setEnabled(false);
     buttonStoreMeasurement_ = new QPushButton("Store Results Measurement", this);
@@ -82,7 +82,7 @@ LStepExpressMeasurementWidget::LStepExpressMeasurementWidget(LStepExpressModel* 
     layout->addWidget(table_view);
 
     QVBoxLayout *vlayout_laser = new QVBoxLayout(this);
-    vlayout_laser->addWidget(checkBoxEnableLaser_);
+    //vlayout_laser->addWidget(checkBoxEnableLaser_);
 
     laserWidget_ = new LaserWidget(laserModel_);
     vlayout_laser->addWidget(laserWidget_);
@@ -99,11 +99,11 @@ LStepExpressMeasurementWidget::LStepExpressMeasurementWidget(LStepExpressModel* 
     layout->addLayout(vlayout);
     
     //make all connections
-    connect(checkBoxEnableLaser_, SIGNAL(toggled(bool)),
-	laserModel_, SLOT(setDeviceEnabled(bool)));
+    //connect(checkBoxEnableLaser_, SIGNAL(toggled(bool)),
+    //	laserModel_, SLOT(setDeviceEnabled(bool)));
 
-    connect(checkBoxEnableLaser_, SIGNAL(toggled(bool)),
-	measurement_model_, SLOT(setLaserEnabled(bool)));
+    //   connect(checkBoxEnableLaser_, SIGNAL(toggled(bool)),
+    //	measurement_model_, SLOT(setLaserEnabled(bool)));
     
     connect(averageMeasCheckBox_, SIGNAL(toggled(bool)),
             measurement_model_, SLOT(setAverageMeasEnabled(bool)));
@@ -119,9 +119,6 @@ LStepExpressMeasurementWidget::LStepExpressMeasurementWidget(LStepExpressModel* 
 
     connect(buttonStoreMeasurement_, SIGNAL(clicked()), this, SLOT(storeResults()));
     
-    connect(laserModel_, SIGNAL(deviceStateChanged(State)),
-	this, SLOT(laserStateChanged(State)));
-
     connect(model_, SIGNAL(deviceStateChanged(State)),
 	this, SLOT(lstepStateChanged(State)));
 
@@ -193,7 +190,7 @@ LStepExpressMeasurementWidget::~LStepExpressMeasurementWidget()
     if(buttonStartMeasurement_){delete buttonStartMeasurement_; buttonStartMeasurement_ = NULL;}
     if(buttonStopMeasurement_){delete buttonStopMeasurement_; buttonStopMeasurement_ = NULL;}
     if(buttonStoreMeasurement_){delete buttonStoreMeasurement_; buttonStoreMeasurement_ = NULL;}
-    if(checkBoxEnableLaser_){delete checkBoxEnableLaser_; checkBoxEnableLaser_ = NULL;}
+    //if(checkBoxEnableLaser_){delete checkBoxEnableLaser_; checkBoxEnableLaser_ = NULL;}
     if(zigzagCheckBox_){delete zigzagCheckBox_; zigzagCheckBox_ = NULL;}
 }
 
@@ -234,7 +231,7 @@ void LStepExpressMeasurementWidget::printSpyInformation()
 void LStepExpressMeasurementWidget::laserStateChanged(State newState)
 {
   //    NQLog("LStepExpressMeasurementWidget ", NQLog::Debug) << "laserStateChanged(State newState) " << newState    ;
-    checkBoxEnableLaser_->setChecked(newState == READY || newState == INITIALIZING);
+  //  checkBoxEnableLaser_->setChecked(newState == READY || newState == INITIALIZING);
 }
 
 void LStepExpressMeasurementWidget::lstepStateChanged(State newState)

--- a/assembly/assemblyCommon/LStepExpressMeasurementWidget.h
+++ b/assembly/assemblyCommon/LStepExpressMeasurementWidget.h
@@ -51,7 +51,7 @@ protected:
     QPushButton *buttonStartMeasurement_;
     QPushButton *buttonStopMeasurement_;
     QPushButton *buttonStoreMeasurement_;
-    QCheckBox *checkBoxEnableLaser_;
+    //    QCheckBox *checkBoxEnableLaser_;
     QCheckBox *zigzagCheckBox_;
     QLineEdit* x_min_;
     QLineEdit* x_max_;

--- a/assembly/assemblyCommon/LaserControlsWidget.cc
+++ b/assembly/assemblyCommon/LaserControlsWidget.cc
@@ -10,6 +10,9 @@ LaserControlsWidget::LaserControlsWidget(LaserModel* model,
     QVBoxLayout *layout = new QVBoxLayout(this);
     setLayout(layout);
 
+    checkBoxEnableLaser_ = new QCheckBox("Enable Laser", this);
+    layout->addWidget(checkBoxEnableLaser_);
+
     QHBoxLayout *samplingLayout = new QHBoxLayout(this);
     layout->addLayout(samplingLayout);
     QHBoxLayout *averagingLayout = new QHBoxLayout(this);
@@ -67,5 +70,15 @@ LaserControlsWidget::LaserControlsWidget(LaserModel* model,
 	laserModel_, SLOT(setMaterialMode(int)));
     connect(diffuseBox_, SIGNAL(currentIndexChanged(int)),
 	laserModel_, SLOT(setDiffuseMode(int)));
-    
+    connect(checkBoxEnableLaser_, SIGNAL(toggled(bool)),
+            laserModel_, SLOT(setDeviceEnabled(bool)));
+
+    connect(laserModel_, SIGNAL(deviceStateChanged(State)),
+	this, SLOT(laserStateChanged(State)));
+
+}
+
+void LaserControlsWidget::laserStateChanged(State newState)
+{
+    checkBoxEnableLaser_->setChecked(newState == READY || newState == INITIALIZING  );
 }

--- a/assembly/assemblyCommon/LaserControlsWidget.cc
+++ b/assembly/assemblyCommon/LaserControlsWidget.cc
@@ -1,0 +1,71 @@
+#include <nqlogger.h>
+
+#include "LaserControlsWidget.h"
+
+LaserControlsWidget::LaserControlsWidget(LaserModel* model,
+			     QWidget* parent)
+    : QWidget(parent),
+      laserModel_(model)
+{
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    setLayout(layout);
+
+    QHBoxLayout *samplingLayout = new QHBoxLayout(this);
+    layout->addLayout(samplingLayout);
+    QHBoxLayout *averagingLayout = new QHBoxLayout(this);
+    layout->addLayout(averagingLayout);
+    QHBoxLayout *materialLayout = new QHBoxLayout(this);
+    layout->addLayout(materialLayout);
+    QHBoxLayout *diffuseLayout = new QHBoxLayout(this);
+    layout->addLayout(diffuseLayout);
+
+    QLabel *samplingLabel_ = new QLabel("sampling rate");
+    samplingBox_ = new QComboBox(this);
+    samplingBox_->addItem("20 microsec");
+    samplingBox_->addItem("50 microsec");
+    samplingBox_->addItem("100 microsec");
+    samplingBox_->addItem("200 microsec");
+    samplingBox_->addItem("500 microsec");
+    samplingBox_->addItem("1000 microsec");
+    samplingLayout->addWidget(samplingLabel_);
+    samplingLayout->addWidget(samplingBox_);
+    QLabel *averagingLabel_ = new QLabel("averaging rate");
+    averagingBox_ = new QComboBox(this);
+    averagingBox_->addItem("1");
+    averagingBox_->addItem("4");
+    averagingBox_->addItem("16");
+    averagingBox_->addItem("64");
+    averagingBox_->addItem("256");
+    averagingBox_->addItem("1024");
+    averagingBox_->addItem("4096");
+    averagingBox_->addItem("16384");
+    averagingBox_->addItem("65536");
+    averagingBox_->addItem("262144");
+    averagingLayout->addWidget(averagingLabel_);
+    averagingLayout->addWidget(averagingBox_);
+    QLabel *materialLabel_ = new QLabel("material mode");
+    materialBox_ = new QComboBox(this);
+    materialBox_->addItem("normal");
+    materialBox_->addItem("translucent 1");
+    materialBox_->addItem("translucent 2");
+    materialBox_->addItem("translucent 3");
+    materialBox_->addItem("multi-reflective");
+    materialLayout->addWidget(materialLabel_);
+    materialLayout->addWidget(materialBox_);
+    QLabel *diffuseLabel_ = new QLabel("diffuse mode");
+    diffuseBox_ = new QComboBox(this);
+    diffuseBox_->addItem("normal");
+    diffuseBox_->addItem("mirror reflection");
+    diffuseLayout->addWidget(diffuseLabel_);
+    diffuseLayout->addWidget(diffuseBox_);
+
+    connect(samplingBox_, SIGNAL(currentIndexChanged(int)),
+	laserModel_, SLOT(setSamplingRate(int)));
+    connect(averagingBox_, SIGNAL(currentIndexChanged(int)),
+	laserModel_, SLOT(setAveragingRate(int)));
+    connect(materialBox_, SIGNAL(currentIndexChanged(int)),
+	laserModel_, SLOT(setMaterialMode(int)));
+    connect(diffuseBox_, SIGNAL(currentIndexChanged(int)),
+	laserModel_, SLOT(setDiffuseMode(int)));
+    
+}

--- a/assembly/assemblyCommon/LaserControlsWidget.h
+++ b/assembly/assemblyCommon/LaserControlsWidget.h
@@ -1,0 +1,35 @@
+#ifndef LASERCONTROLSWIDGET_H
+#define LASERCONTROLSWIDGET_H
+
+#include <vector>
+
+#include <QCheckBox>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QLCDNumber>
+#include <QVBoxLayout>
+#include <QComboBox>
+#include <QWidget>
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QTimer>
+
+#include "LaserModel.h"
+
+class LaserControlsWidget : public QWidget
+{
+    Q_OBJECT
+
+ public:
+    explicit LaserControlsWidget(LaserModel* model, QWidget *parent = 0);
+
+ protected:
+    LaserModel* laserModel_;
+    QComboBox* samplingBox_;
+    QComboBox* averagingBox_;
+    QComboBox* materialBox_;
+    QComboBox* diffuseBox_;
+};
+
+#endif // LASERCONTROLSWIDGET_H

--- a/assembly/assemblyCommon/LaserControlsWidget.h
+++ b/assembly/assemblyCommon/LaserControlsWidget.h
@@ -30,6 +30,10 @@ class LaserControlsWidget : public QWidget
     QComboBox* averagingBox_;
     QComboBox* materialBox_;
     QComboBox* diffuseBox_;
+    QCheckBox* checkBoxEnableLaser_;
+
+    public slots:
+        void laserStateChanged(State newState);
 };
 
 #endif // LASERCONTROLSWIDGET_H

--- a/assembly/assemblyCommon/LaserModel.cc
+++ b/assembly/assemblyCommon/LaserModel.cc
@@ -46,6 +46,18 @@ void LaserModel::setAveraging(int mode)
     controller_->SetAveraging(laserHead_, mode);
 }
 
+void LaserModel::setMaterialMode(int mode)
+{
+    if(state_ == OFF) return;
+    controller_->SetMaterialMode(laserHead_, mode);
+}
+
+void LaserModel::setDiffuseMode(int mode)
+{
+    if(state_ == OFF) return;
+    controller_->SetDiffuseMode(laserHead_, mode);
+}
+
 void LaserModel::updateInformation()
 {
     double value = 0;

--- a/assembly/assemblyCommon/LaserModel.h
+++ b/assembly/assemblyCommon/LaserModel.h
@@ -30,8 +30,6 @@ public:
                                QObject *parent = 0);
     ~LaserModel();
 
-    void setSamplingRate(int mode);
-    void setAveraging(int mode);
     void setLaserHead(int out);
     void setMeasurement(double value); //dummy method for testing
 
@@ -39,6 +37,10 @@ public slots:
 
     void setDeviceEnabled(bool enabled = true);
     void getMeasurement(double& value);
+    void setSamplingRate(int mode);
+    void setAveraging(int mode);
+    void setDiffuseMode(int mode);
+    void setMaterialMode(int mode);
 
 protected:
 

--- a/assembly/assemblyCommon/assemblyCommon.pro.in
+++ b/assembly/assemblyCommon/assemblyCommon.pro.in
@@ -89,7 +89,8 @@ HEADERS += AssemblyVUEyeCamera.h \
            LStepExpressStatusWindow.h \
            LaserModel.h \
            LaserWidget.h \
-           LaserThread.h
+           LaserThread.h \
+           LaserControlsWidget.h 
 
 equals(USEFAKEDEVICES,"X0") {
 HEADERS += AssemblyUEyeCamera.h \
@@ -125,7 +126,8 @@ SOURCES += AssemblyVUEyeCamera.cc \
            LStepExpressStatusWindow.cc \
            LaserModel.cc \
            LaserWidget.cc \
-           LaserThread.cc
+           LaserThread.cc \ 
+           LaserControlsWidget.cc
 
 equals(USEFAKEDEVICES,"X0") {
 SOURCES += AssemblyUEyeCamera.cc \

--- a/assembly/motion/motionCommander/MCommanderMainWindow.cc
+++ b/assembly/motion/motionCommander/MCommanderMainWindow.cc
@@ -69,6 +69,9 @@ MCommanderMainWindow::MCommanderMainWindow(QWidget *parent)
   layout->addLayout(layoutv2);
   
   tabWidget_->addTab(widget, "LStep Express");
+
+  LaserControlsWidget *laserControlsWidget = new LaserControlsWidget(laserModel_, widget);
+  tabWidget_->addTab(laserControlsWidget, "Laser Control");
   
   //  LStepExpressSettingsWidget *lStepExpressSettingsWidget = new LStepExpressSettingsWidget(lStepExpressSettings_, tabWidget_);
   //tabWidget_->addTab(lStepExpressSettingsWidget, "LStep Express Settings");

--- a/assembly/motion/motionCommander/MCommanderMainWindow.cc
+++ b/assembly/motion/motionCommander/MCommanderMainWindow.cc
@@ -67,6 +67,9 @@ MCommanderMainWindow::MCommanderMainWindow(QWidget *parent)
   layoutv2->addWidget(lStepPosition);
   
   layout->addLayout(layoutv2);
+  LaserWidget *laserWidget_ = new LaserWidget(laserModel_);
+  laserWidget_->setMinimumWidth(400);
+  layout->addWidget(laserWidget_);
   
   tabWidget_->addTab(widget, "LStep Express");
 

--- a/assembly/motion/motionCommander/MCommanderMainWindow.h
+++ b/assembly/motion/motionCommander/MCommanderMainWindow.h
@@ -21,6 +21,7 @@
 #include "LStepExpressMeasurementWidget.h"
 #include "LStepExpressPositionWidget.h"
 #include "LStepExpressStatusWindow.h"
+#include "LaserControlsWidget.h"
 
 #include "LaserModel.h"
 #include "LaserThread.h"


### PR DESCRIPTION
Added a tab to the motion commander to enable and control the laser settings (such as sampling rate, mode for transparent or multi-reflective material, ...)
the LStep window now also has a window with the laser output
